### PR TITLE
Fix unhandled exceptions

### DIFF
--- a/src/Exceptional/Models/ConstructorDeclarationModel.cs
+++ b/src/Exceptional/Models/ConstructorDeclarationModel.cs
@@ -27,7 +27,7 @@ namespace ReSharper.Exceptional.Models
                     var containingType = constructorDeclaration.DeclaredElement.GetContainingType();
                     var baseClass = containingType?.GetSuperTypes().FirstOrDefault(t => !t.IsInterfaceType());
                     var baseClassTypeElement = baseClass?.GetTypeElement();
-                    var defaultBaseConstructor = baseClassTypeElement?.Constructors.First(c => c.IsDefault);
+                    var defaultBaseConstructor = baseClassTypeElement?.Constructors.FirstOrDefault(c => c.IsDefault);
                     if (defaultBaseConstructor != null)
                     {
                         ThrownExceptions.Add(new ConstructorInitializerModel(this, defaultBaseConstructor, this));

--- a/src/Exceptional/Models/ExceptionsOrigins/ThrowStatementModel.cs
+++ b/src/Exceptional/Models/ExceptionsOrigins/ThrowStatementModel.cs
@@ -151,7 +151,7 @@ namespace ReSharper.Exceptional.Models.ExceptionsOrigins
 
         private IDeclaredType GetExceptionType()
         {
-            if (Node.Exception != null)
+            if (Node?.Exception != null)
             {
                 return Node.Exception.GetExpressionType() as IDeclaredType;
             }


### PR DESCRIPTION
Hi, I'm from JetBrains

Thanks for maintaining this fork!

We receive exception reports from customers who use this plugin.

[First one](https://youtrack.jetbrains.com/issue/DEXP-614140)
```
StackTraceString = “
at System.Linq.Enumerable.First[TSource](IEnumerable`1 source, Func`2 predicate)
at ReSharper.Exceptional.Models.ConstructorDeclarationModel..ctor(IConstructorDeclaration constructorDeclaration) in E:\Developments\.Net\C#\Repo\C#\ExceptionalReSharper\src\Exceptional\Models\ConstructorDeclarationModel.cs:line 30
at ReSharper.Exceptional.ExceptionalRecursiveElementProcessor.ProcessBeforeInterior(ITreeNode element) in E:\Developments\.Net\C#\Repo\C#\ExceptionalReSharper\src\Exceptional\ExceptionalRecursiveElementProcessor.cs:line 103
at JetBrains.ReSharper.Psi.RecursiveElementProcessorExtensions.ProcessDescendants(ITreeNode root, IRecursiveElementProcessor processor)
at ReSharper.Exceptional.ExceptionalDaemonStageProcess.Execute(Action`1 commiter) in E:\Developments\.Net\C#\Repo\C#\ExceptionalReSharper\src\Exceptional\ExceptionalDaemonStageProcess.cs:line 53
at JetBrains.ReSharper.Feature.Services.Daemon.DaemonProcessBase.RunStage(IDaemonStage stage, DaemonProcessKind processKind, Action`2 commiter, IContextBoundSettingsStore contextBoundSettingsStore, JetHashSet`1 disabledStages)
```

Second
[Object reference not set to an instance of an object](https://youtrack.jetbrains.com/issue/DEXP-616069).
```
at ReSharper.Exceptional.Models.ExceptionsOrigins.ThrowStatementModel.GetExceptionType() in E:\Developments\.Net\C#\Repo\C#\ExceptionalReSharper\src\Exceptional\Models\ExceptionsOrigins\ThrowStatementModel.cs:line 154
at ReSharper.Exceptional.Models.ExceptionsOrigins.ThrowStatementModel..ctor(IAnalyzeUnit analyzeUnit, IThrowStatement throwStatement, IBlockModel containingBlock) in E:\Developments\.Net\C#\Repo\C#\ExceptionalReSharper\src\Exceptional\Models\ExceptionsOrigins\ThrowStatementModel.cs:line 33
at ReSharper.Exceptional.Contexts.ProcessContext`1.Process(IThrowStatement throwStatement) in E:\Developments\.Net\C#\Repo\C#\ExceptionalReSharper\src\Exceptional\Contexts\ProcessContext.cs:line 108
at ReSharper.Exceptional.ExceptionalRecursiveElementProcessor.ProcessBeforeInterior(ITreeNode element) in E:\Developments\.Net\C#\Repo\C#\ExceptionalReSharper\src\Exceptional\ExceptionalRecursiveElementProcessor.cs:line 79
at JetBrains.ReSharper.Psi.RecursiveElementProcessorExtensions.ProcessDescendants(ITreeNode root, IRecursiveElementProcessor processor)
at ReSharper.Exceptional.ExceptionalDaemonStageProcess.Execute(Action`1 commiter) in E:\Developments\.Net\C#\Repo\C#\ExceptionalReSharper\src\Exceptional\ExceptionalDaemonStageProcess.cs:line 53
at JetBrains.ReSharper.Feature.Services.Daemon.DaemonProcessBase.RunStage(IDaemonStage stage, DaemonProcessKind processKind, Action`2 commiter, IContextBoundSettingsStore contextBoundSettingsStore, JetHashSet`1 disabledStages)

```

Proposed PR should fix both.