### PR TITLE
add dependency on FilteringHighlightingDaemonStage

### DIFF
--- a/src/Exceptional/ExceptionalDaemonStage.cs
+++ b/src/Exceptional/ExceptionalDaemonStage.cs
@@ -41,7 +41,7 @@ namespace ReSharper.Exceptional.MF
     /// marks this type so that it will be automatically loaded by ReSharper. To work properly the
     /// marked type must implement <see cref="IDaemonStage" /> interface.
     /// </remarks>
-    [DaemonStage]
+    [DaemonStage(StagesBefore = new [] {typeof(FilteringHighlightingDaemonStage)})]
     public class ExceptionalDaemonStage : CSharpDaemonStageBase
     {
         #region methods


### PR DESCRIPTION
add dependency on FilteringHighlightingDaemonStage for FilteringHighlightingConsumer to work properly. Fix for https://youtrack.jetbrains.com/issue/RSRP-476959

the fix was made by @sirduke